### PR TITLE
Fix workflow URL

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    uses: RaphaelIT7/gmodcommon-module-base/.github/workflows/compile.yml@workflow
+    uses: RaphaelIT7/gmod-common-module-base/.github/workflows/compile.yml@workflow
     with:
       PROJECT_NAME: "template"
       BUILD_64x: "true"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Example of the workflow:
 ```yml
 jobs:
   build:
-    uses: RaphaelIT7/gmodcommon-module-base/.github/workflows/compile.yml@workflow
+    uses: RaphaelIT7/gmod-common-module-base/.github/workflows/compile.yml@workflow
     with:
       PROJECT_NAME: "template"
       BUILD_64x: "true"


### PR DESCRIPTION
The repo URL updated, so the link for the reusable workflow needs to be updated too 😁 

```
-> "RaphaelIT7/gmodcommon-module-base/.github/workflows/compile.yml@workflow"
: workflow was not found. See https://docs.github.com/actions/learn-github-actions/reusing-workflows#access-to-reusable-workflows for more information.
```