### PR TITLE
Fix submodule checkout for non-Linux build targets

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -375,6 +375,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         name: Checkout
+        with:
+          submodules: recursive
 
       - uses: actions/checkout@v4
         name: Checkout garrysmod_common
@@ -507,6 +509,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         name: Checkout
+        with:
+          submodules: recursive
 
       - uses: actions/checkout@v4
         name: Checkout garrysmod_common
@@ -601,6 +605,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         name: Checkout
+        with:
+          submodules: recursive
 
       - uses: actions/checkout@v4
         name: Checkout garrysmod_common


### PR DESCRIPTION
Sorry, I just noticed that I only enabled submodule checkout for the Linux build, not for the others. XD